### PR TITLE
Fix function component behavior; pass displayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ This change log follows the format documented in [Keep a CHANGELOG].
 
 ## Unreleased
 
+## 0.3.0 - 2016-11-20
+
+### Fixed
+
+- Fix function components behaviour. Now the guarded function
+  accepts 3 arguments instead of just 1:
+  `props`, `publicContext` and `updateQueue`.
+
+### Added
+
+- Pass `displayName` to the guard function.
+
+## 0.2.0 - 2016-11-18
+
 ### Added
 
 - Classes & function components support.
@@ -20,4 +34,6 @@ This change log follows the format documented in [Keep a CHANGELOG].
 
 Initial release.
 
-[Unreleased]: https://github.com/kossnocorp/react-guard/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/kossnocorp/react-guard/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/kossnocorp/react-guard/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/kossnocorp/react-guard/compare/v0.1.0...v0.2.0

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,4 @@
+# License
+
+react-guard is licensed under the [MIT license](http://kossnocorp.mit-license.org).
+Read more about MIT at [TLDRLegal](https://tldrlegal.com/license/mit-license).

--- a/README.md
+++ b/README.md
@@ -1,23 +1,53 @@
 # React Guard
 
+React Guard helps to prevent White Screen of Death,
+improves user expirience and assists in the bug hunt.
+
+It patches React, so it wraps every render function (including
+function components) intro try-catch block.
+
+If an exception occurs during the rendering, it calls specified guard function.
+The guard function gets the exception object and extra information such as
+the component `props`, `state` and `displayName`.
+
 ## Installation
 
 ```
-npm install --save react-guard
+npm install react-guard --save
+```
+
+or
+
+```
+yarn add react-guard
 ```
 
 ## Usage
 
-``` javascript
-var React = require('react/addons');
-var reactGuard = require('react-guard');
+```javascript
+var React = require('react')
+var reactGuard = require('react-guard')
 
-reactGuard(React, function(error) {
-  // Process catched error, extract stack trace, save error data to
-  // exception catcher etc
-});
+// Catch and process component render exceptions.
+reactGuard(React, function (err, componentInfo) {
+  // Print stacktrace to the console
+  console && console.error && console.error(err.stack)
 
-window.React = React;
+  // Notify Sentry (replace with your service of choice)
+  Raven.captureException(err, {
+    extra: {
+      props: componentInfo.props,
+      state: componentInfo.state,
+      displayName: componentInfo.displayName
+    }
+  })
 
+  // Replace failed component with "Failed to render".
+  // Use `return null` to render nothing.
+  return <div>Failed to render</div>
+})
 ```
 
+## License
+
+[MIT © Sasha Koss](https://kossnocorp.mit-license.org/)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 /* eslint-disable no-redeclare */
 
-// XXX: This is highly optimized realization, see naive.js
-// for the logic reference.
+// XXX: This is highly optimized implementation, used in production
+// see naive.js for the logic reference.
+//
+// See V8 Bailout Reasons for optimization reference:
+// https://github.com/vhf/v8-bailout-reasons
 var reactGuard = function (React, guardFn) {
   guardFn = guardFn || function () { return null }
 
@@ -9,16 +12,20 @@ var reactGuard = function (React, guardFn) {
     try {
       return this.__guardedRender__()
     } catch (err) {
-      return guardFn(err, {props: this.props, state: this.state})
+      return guardFn(err, {
+        props: this.props,
+        state: this.state,
+        displayName: this.constructor.displayName
+      })
     }
   }
 
   function buildFunctionComponent (type) {
-    return function (props) {
+    return function (props, publicContext, updateQueue) {
       try {
-        return type(props)
+        return type(props, publicContext, updateQueue)
       } catch (err) {
-        return guardFn(err, {props: props})
+        return guardFn(err, {props: props, displayName: type.displayName})
       }
     }
   }

--- a/naive.js
+++ b/naive.js
@@ -1,3 +1,5 @@
+// XXX: This is a naive implementation, see index.js
+// for optimized, production verion.
 var naiveReactGuard = function (React, guardFn) {
   guardFn = guardFn || function () { return null }
 
@@ -9,16 +11,20 @@ var naiveReactGuard = function (React, guardFn) {
         try {
           return this.__guardedRender__()
         } catch (err) {
-          return guardFn(err, {props: this.props, state: this.state})
+          return guardFn(err, {
+            props: this.props,
+            state: this.state,
+            displayName: this.constructor.displayName
+          })
         }
       }
     } else if (typeof type === 'function' && !('render' in type.prototype)) {
       var guardedType = type
-      type = function (props) {
+      type = function (props, publicContext, updateQueue) {
         try {
-          return guardedType(props)
+          return guardedType(props, publicContext, updateQueue)
         } catch (err) {
-          return guardFn(err, {props: props})
+          return guardFn(err, {props: props, displayName: guardedType.displayName})
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "react-guard",
-  "version": "0.2.0",
-  "author": "Sasha Koss <kossnocorp@gmail.com>",
+  "version": "0.3.0",
+  "author": "Sasha Koss <koss@nocorp.me>",
   "description": "React Guard automagically catches exceptions from React components, extracts useful debug information and prevents White Screen of Death",
+  "license": "MIT",
   "main": "index.js",
   "repository": "https://github.com/kossnocorp/react-guard",
   "engine": {

--- a/test/react-15/index.js
+++ b/test/react-15/index.js
@@ -19,10 +19,11 @@ test.always.afterEach(() => {
       getInitialState () { return {b: 'B'} },
       render () { throw {error: 'test'} }
     })
+    CreateClassComponent.displayName = 'CreateClassComponent'
     const result = ReactDOMServer.renderToStaticMarkup(React.createElement(CreateClassComponent, {a: 'A'}, 'children'))
     t.is(result, '<div>w00t</div>')
     t.true(guardSpy.called)
-    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}, state: {b: 'B'}}))
+    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}, state: {b: 'B'}, displayName: 'CreateClassComponent'}))
   })
 
   test(`${title} › a warm component created using React.createClass`, t => {
@@ -47,10 +48,11 @@ test.always.afterEach(() => {
       }
       render () { throw {error: 'test'} }
     }
+    ClassComponent.displayName = 'ClassComponent'
     const result = ReactDOMServer.renderToStaticMarkup(React.createElement(ClassComponent, {a: 'A'}, 'children'))
     t.is(result, '<div>w00t</div>')
     t.true(guardSpy.called)
-    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}, state: {b: 'B'}}))
+    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}, state: {b: 'B'}, displayName: 'ClassComponent'}))
   })
 
   test(`${title} › a warm component inherited from React.Component`, t => {
@@ -65,26 +67,17 @@ test.always.afterEach(() => {
     t.is(result, '<div>w00t</div>')
   })
 
-  test(`${title} › a warm component inherited from React.Component`, t => {
-    reactGuardFn(React)
-    class ClassComponent extends React.Component {
-      render () { return React.createElement('div', {}, 'w', '0', '0', 't') }
-    }
-    React.createElement(ClassComponent, {a: 'A'}, 'children')
-    const result = ReactDOMServer.renderToStaticMarkup(React.createElement(ClassComponent, {a: 'A'}, 'children'))
-    t.is(result, '<div>w00t</div>')
-  })
-
   test(`${title} › a component inherited from React.PureComponent`, t => {
     const guardSpy = sinon.spy(() => React.createElement('div', {}, 'w', '0', '0', 't'))
     reactGuardFn(React, guardSpy)
     class PureClassComponent extends React.PureComponent {
       render () { throw {error: 'test'} }
     }
+    PureClassComponent.displayName = 'PureClassComponent'
     const result = ReactDOMServer.renderToStaticMarkup(React.createElement(PureClassComponent, {a: 'A'}, 'children'))
     t.is(result, '<div>w00t</div>')
     t.true(guardSpy.called)
-    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}, state: null}))
+    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}, state: null, displayName: 'PureClassComponent'}))
   })
 
   test(`${title} › a warm component inherited from React.PureComponent`, t => {
@@ -101,10 +94,11 @@ test.always.afterEach(() => {
     const guardSpy = sinon.spy(() => React.createElement('div', {}, 'w', '0', '0', 't'))
     reactGuardFn(React, guardSpy)
     const FunctionComponent = () => { throw {error: 'test'} }
+    FunctionComponent.displayName = 'FunctionComponent'
     const result = ReactDOMServer.renderToStaticMarkup(React.createElement(FunctionComponent, {a: 'A'}, 'children'))
     t.is(result, '<div>w00t</div>')
     t.true(guardSpy.called)
-    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}}))
+    t.true(guardSpy.calledWith({error: 'test'}, {props: {a: 'A', children: 'children'}, displayName: 'FunctionComponent'}))
   })
 
   test(`${title} › a warm function component`, t => {
@@ -121,4 +115,32 @@ test.always.afterEach(() => {
     const result = ReactDOMServer.renderToStaticMarkup(React.createElement(FunctionComponent, {a: 'A'}, 'children'))
     t.is(result, '')
   })
+
+  test(`${title} › createElement called on function component passes all 3 arguments`, t => {
+    reactGuardFn(React)
+    const ComponentSpy = sinon.spy()
+    const element = React.createElement(ComponentSpy)
+    element.type({props: true}, {publicContext: true}, {updateQueue: true})
+    t.true(ComponentSpy.calledWith({props: true}, {publicContext: true}, {updateQueue: true}))
+  })
+})
+
+test('restore function restores the original createElement function', t => {
+  const createElement = React.createElement
+  reactGuard(React)
+  reactGuard.restore(React)
+  t.is(React.createElement, createElement)
+})
+
+test('restore function removes cached create element', t => {
+  reactGuard(React)
+  reactGuard.restore(React)
+  t.false('__reactGuardOriginalCreateElement__' in React)
+})
+
+test('restore function saves the original createElement if guard was not called', t => {
+  const createElement = React.createElement
+  reactGuard.restore(React)
+  t.true(typeof createElement === 'function')
+  t.is(React.createElement, createElement)
 })


### PR DESCRIPTION
- Fix function components behavior. Now the guarded function accepts 3 arguments instead of just 1: `props`, `publicContext` and `updateQueue`.
- Pass `displayName` to the guard function.
- Improve docs, add more.
- Set MIT license.