### PR TITLE
Fix stateful components rendered as a a function component children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This change log follows the format documented in [Keep a CHANGELOG].
 
 ## Unreleased
 
+## 0.3.1 - 2016-12-01
+
+### Fixed
+
+- Fix a stateful component missing the state when it's rendered
+  as a function component children.
+- Copy all original function component properties to
+  the wrapped function.
+
 ## 0.3.0 - 2016-11-20
 
 ### Fixed
@@ -34,6 +43,7 @@ This change log follows the format documented in [Keep a CHANGELOG].
 
 Initial release.
 
-[Unreleased]: https://github.com/kossnocorp/react-guard/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/kossnocorp/react-guard/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/kossnocorp/react-guard/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/kossnocorp/react-guard/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/kossnocorp/react-guard/compare/v0.1.0...v0.2.0

--- a/naive.js
+++ b/naive.js
@@ -20,13 +20,21 @@ var naiveReactGuard = function (React, guardFn) {
       }
     } else if (typeof type === 'function' && !('render' in type.prototype)) {
       var guardedType = type
-      type = function (props, publicContext, updateQueue) {
-        try {
-          return guardedType(props, publicContext, updateQueue)
-        } catch (err) {
-          return guardFn(err, {props: props, displayName: guardedType.displayName})
+      var _type
+      if (guardedType.__reactGuardGuardedFunction__) {
+        _type = guardedType.__reactGuardGuardedFunction__
+      } else {
+        _type = function (props, publicContext, updateQueue) {
+          try {
+            return guardedType(props, publicContext, updateQueue)
+          } catch (err) {
+            return guardFn(err, {props: props, displayName: guardedType.displayName})
+          }
         }
+        Object.assign(_type, guardedType)
+        guardedType.__reactGuardGuardedFunction__ = _type
       }
+      type = _type
     }
     return React.__reactGuardOriginalCreateElement__.apply(React, [type].concat(Array.prototype.slice.call(arguments, 1)))
   }

--- a/test/react-15/index.js
+++ b/test/react-15/index.js
@@ -9,6 +9,8 @@ import ReactDOMServer from 'react-dom/server'
 
 test.always.afterEach(() => {
   reactGuard.restore(React)
+  // Restore spy
+  React.createElement.restore && React.createElement.restore()
 })
 
 ;[{title: 'reactGuard', reactGuardFn: reactGuard}, {title: 'Naive reactGuard', reactGuardFn: naiveReactGuard}].forEach(({title, reactGuardFn}) => {
@@ -122,6 +124,27 @@ test.always.afterEach(() => {
     const element = React.createElement(ComponentSpy)
     element.type({props: true}, {publicContext: true}, {updateQueue: true})
     t.true(ComponentSpy.calledWith({props: true}, {publicContext: true}, {updateQueue: true}))
+  })
+
+  test(`${title} › createElement called on function component saves guarded function`, t => {
+    const createElement = sinon.spy(React, 'createElement')
+    reactGuardFn(React)
+    const FunctionComponent = () => { return null }
+    React.createElement(FunctionComponent)
+    React.createElement(FunctionComponent)
+    t.is(createElement.args[0][0], createElement.args[1][0])
+  })
+
+  test(`${title} › createElement called on function saves all original properties`, t => {
+    const createElement = sinon.spy(React, 'createElement')
+    reactGuardFn(React)
+    const FunctionComponent = () => { return null }
+    FunctionComponent.displayName = 'FunctionComponent'
+    FunctionComponent.propTypes = {}
+    React.createElement(FunctionComponent)
+    const FunctionComponentWrapper = createElement.args[0][0]
+    t.is(FunctionComponentWrapper.displayName, 'FunctionComponent')
+    t.is(FunctionComponentWrapper.propTypes, FunctionComponent.propTypes)
   })
 })
 


### PR DESCRIPTION
- Fix a stateful component missing the state when it's rendered as a function component children.
- Copy all original function component properties to the wrapped function.